### PR TITLE
Upgrade kramdown to version 2.3.1 or later

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,9 @@ source 'https://rubygems.org'
 
 gem "github-pages", '193', group: :jekyll_plugins
 
+gem "kramdown", ">=2.3.1"
+
 # enable tzinfo-data for local build
 # gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]
 gem 'jekyll-paginate'
+

--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,8 @@ source 'https://rubygems.org'
 
 gem "github-pages", '193', group: :jekyll_plugins
 
-gem "kramdown", ">=2.3.1"
-
 # enable tzinfo-data for local build
 # gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]
 gem 'jekyll-paginate'
 
+gem "kramdown", ">=2.3.1"


### PR DESCRIPTION
Upgrade kramdown to version 2.3.1 or later per advisory.