### PR TITLE
chore(ci): update dependabot configuration for ruby and docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,18 +5,16 @@
 
 version: 2
 updates:
-  # Enable version updates for npm
-  - package-ecosystem: "npm"
-    # Look for `package.json` and `lock` files in the `root` directory
+  # Enable version updates for Bundler (Ruby gems)
+  - package-ecosystem: "bundler"
     directory: "/"
-    # Check the npm registry for updates every day (weekdays)
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    open-pull-requests-limit: 5
 
   # Enable version updates for Docker
   - package-ecosystem: "docker"
-    # Look for a `Dockerfile` in the `root` directory
     directory: "/"
-    # Check for updates once a week
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 3


### PR DESCRIPTION
Replaced the unused npm ecosystem target with a bundler package-ecosystem tracking configuration to monitor Ruby dependency trees. Also appended request caps (open-pull-requests-limit) on both Docker and Bundler modules to manage incoming security update PR volumes efficiently.

Please note that if you are trying to update **your** website, this is the wrong place to do so. Please carefully follow the Beautiful Jekyll instructions (found at https://github.com/daattali/beautiful-jekyll#readme) and make sure you submit changes to **your** version of the project.

If your intention is to submit a Pull Request, please describe what your pull request achieves.

Thank you!
