### PR TITLE
Potential fix for code scanning alert no. 1: Unsafe jQuery plugin

### DIFF
--- a/js/bootstrap.js
+++ b/js/bootstrap.js
@@ -544,7 +544,9 @@ if (typeof jQuery === 'undefined') {
   var Collapse = function (element, options) {
     this.$element      = $(element)
     this.options       = $.extend({}, Collapse.DEFAULTS, options)
-    this.$trigger      = $(this.options.trigger).filter('[href="#' + element.id + '"], [data-target="#' + element.id + '"]')
+    var trigger        = this.options.trigger
+    var $trigger       = typeof trigger == 'string' ? $($.find(trigger)) : $(trigger)
+    this.$trigger      = $trigger.filter('[href="#' + element.id + '"], [data-target="#' + element.id + '"]')
     this.transitioning = null
 
     if (this.options.parent) {


### PR DESCRIPTION
Potential fix for [https://github.com/aawc/aawc.github.com/security/code-scanning/1](https://github.com/aawc/aawc.github.com/security/code-scanning/1)

General fix: ensure plugin options that are expected to represent elements/selectors are normalized so they cannot be interpreted as HTML by jQuery constructor. Prefer DOM elements/jQuery objects directly; if a string is provided, resolve it as a selector using `$.find` (selector-only) and then wrap the result.

Best targeted fix in `js/bootstrap.js`:
- In the `Collapse` constructor (around line 547), replace direct `$(this.options.trigger)` with guarded logic:
  - if `this.options.trigger` is a string, resolve via `$.find(this.options.trigger)` and wrap with `$()`;
  - otherwise keep existing behavior with `$(this.options.trigger)`.
- Keep existing `.filter(...)` behavior unchanged so functionality remains the same.
- No new dependency is required; uses existing jQuery APIs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
