### PR TITLE
Add GitHub Actions workflow for weekly CodeQL analysis

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,43 @@
+name: "CodeQL Analysis"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '0 0 * * 0' # Runs weekly on Sundays at 00:00 UTC
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'javascript' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+
+    # Autobuild attempts to build any compiled languages.
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
+
+    # Perform the analysis.
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2
+      with:
+        category: "/language:${{matrix.language}}"


### PR DESCRIPTION
ci: Add GitHub Actions workflow for weekly CodeQL analysis

Sets up a GitHub Actions workflow to run CodeQL security scans on the
codebase. This configuration focuses on client-side JavaScript to detect
common vulnerabilities (like XSS or code injection).

Details:
- Configures CodeQL to run automatically once a week (Sundays at 00:00 UTC).
- Triggers validation scans on every push or pull request targeting the 'main' branch.
- Integrates scanning results with the repository's GitHub Security dashboard.